### PR TITLE
Allow custom projectDir

### DIFF
--- a/src/Kernel/Kernel.php
+++ b/src/Kernel/Kernel.php
@@ -34,11 +34,11 @@ class Kernel implements KernelInterface
     /**
      * Kernel constructor.
      */
-    public function __construct(string $environment, bool $debug = false)
+    public function __construct(string $environment, bool $debug = false, ?string $projectDir = null)
     {
         $this->environment = $environment;
         $this->debug = $debug;
-        $this->projectDir = $this->getProjectDir();
+        $this->projectDir = $projectDir ?? $this->getProjectDir();
     }
 
     public function boot()


### PR DESCRIPTION
This allows to boot the kernel in a test environment for example.

I got inspired by Symfony => https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/Kernel.php#L86